### PR TITLE
Fix USE_SINGLE_COMMENT_REVIEW boolean logic to prevent GitHub API errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9,7 +9,7 @@ const EXCLUDE_PATHS = ((_a = process.env.EXCLUDE_PATHS) === null || _a === void 
 const LANGUAGE = process.env.LANGUAGE || "English";
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
 const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash-exp";
-const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW || false;
+const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true';
 if (!GITHUB_TOKEN) {
     throw new Error("GITHUB_TOKEN is missing");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const EXCLUDE_PATHS = process.env.EXCLUDE_PATHS?.split(',').map(p => p.trim()) |
 const LANGUAGE = process.env.LANGUAGE || "English"
 const PR_NUMBER = Number(process.env.GITHUB_PR_NUMBER) || 1;
 const MODEL_CODE = process.env.MODEL_CODE || "models/gemini-2.0-flash-exp"
-const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW || false
+const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true'
 
 if (!GITHUB_TOKEN) {
     throw new Error("GITHUB_TOKEN is missing");


### PR DESCRIPTION
## Problem
The `USE_SINGLE_COMMENT_REVIEW` environment variable was not working correctly due to improper boolean evaluation:

```typescript
// ❌ Bug: String "false" evaluates to true in JavaScript
const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW || false
```

This caused:
- `USE_SINGLE_COMMENT_REVIEW=false` → `true` (unexpected\!)
- Always used line-by-line comments instead of single comment review
- GitHub API errors: "Pull request review thread line must be part of the diff"

## Solution
Fixed boolean evaluation to properly handle string environment variables:

```typescript
// ✅ Fixed: Proper string-to-boolean conversion
const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true'
```

## Behavior After Fix
- `undefined` or not set → `false` (default: line-by-line comments)
- `USE_SINGLE_COMMENT_REVIEW=true` → `true` (single comment review)
- `USE_SINGLE_COMMENT_REVIEW=false` → `false` (line-by-line comments)

## Impact
- Resolves GitHub API 422 errors when AI generates invalid line numbers
- Enables proper fallback to single comment mode
- Allows users to explicitly choose review format

## Files Changed
- `src/index.ts`: Fixed boolean logic
- `dist/index.js`: Rebuilt with corrected logic

## Testing
This fix should resolve the error seen in:
https://github.com/smkwlab/thesis-management-tools/pull/139/checks

The AI reviewer will now properly respect the `USE_SINGLE_COMMENT_REVIEW` setting.