### PR TITLE
Fix missing USE_SINGLE_COMMENT_REVIEW input parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: "Patterns to exclude from review (comma-separated)"
     required: false
     default: ""
+  USE_SINGLE_COMMENT_REVIEW:
+    description: "Use single comment review instead of line-by-line comments"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -48,3 +52,4 @@ runs:
         LANGUAGE: ${{ inputs.LANGUAGE }}
         MODEL_CODE: ${{ inputs.MODEL_CODE }}
         EXCLUDE_PATHS: ${{ inputs.EXCLUDE_PATHS }}
+        USE_SINGLE_COMMENT_REVIEW: ${{ inputs.USE_SINGLE_COMMENT_REVIEW }}


### PR DESCRIPTION
## Summary

Fix the missing `USE_SINGLE_COMMENT_REVIEW` input parameter definition in action.yml that was causing GitHub Actions workflow warnings and API errors.

## Problem

The parameter `USE_SINGLE_COMMENT_REVIEW` was being used in the source code but was not defined as an input in action.yml, causing:

1. **GitHub Actions Warning**: "Unexpected input(s) 'USE_SINGLE_COMMENT_REVIEW'"
2. **Workflow failures**: GitHub API 422 errors when trying to post reviews  
3. **Inconsistent behavior**: Parameter was read from environment but not formally defined

## Solution

- Add `USE_SINGLE_COMMENT_REVIEW` as a formal input parameter in action.yml
- Set appropriate description and default value ("false")
- Map input to environment variable in the composite action

## Changes

### action.yml
- Added `USE_SINGLE_COMMENT_REVIEW` input parameter definition
- Added environment variable mapping in the run steps

## Testing

This fixes the issue seen in workflows like smkwlab/thesis-management-tools where the parameter was being used but caused warnings and failures.

## Backward Compatibility

- Default value is "false" to maintain existing behavior
- Existing workflows that don't specify this parameter will continue to work
- Workflows that do specify it will no longer generate warnings

## References

- Used in src/index.ts line 10: `const USE_SINGLE_COMMENT_REVIEW = process.env.USE_SINGLE_COMMENT_REVIEW === 'true'`
- Used in src/index.ts line 29: `generateReviewCommentFn: USE_SINGLE_COMMENT_REVIEW ? generateReviewCommentText : generateReviewCommentObject`