### PR TITLE
Update default model to gemini-2.5-flash

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,12 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Gemini Review Bot
-        uses: Nasubikun/ai-reviewer@v1
+        uses: toshi0806/ai-reviewer@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           LANGUAGE: "Japanese"
           EXCLUDE_PATHS: "**/pnpm-lock.yaml"
+          MODEL_CODE: "models/gemini-2.5-flash-lite"
 ```
 Github Secretsに`GEMINI_API_KEY`としてGoogle AI StudioのGemini API Keyを設定します。
 
@@ -40,5 +41,5 @@ Github Secretsに`GEMINI_API_KEY`としてGoogle AI StudioのGemini API Keyを�
 |--------------------------|------------|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **EXCLUDE_PATHS**        | false       | -                                | レビューから除外したいファイルパスやディレクトリをカンマ区切りで指定します。例: `src/vendor,**/dist/*`<br>ここで指定されたパスに該当するファイルはレビューの対象外となります。                                    |
 | **LANGUAGE**             | false       | `English`                        | AIが生成するコメントの言語を指定します。例: `Japanese`, `English`など。                                                                                                          |                                                                                       |
-| **MODEL_CODE**           | false       | `models/gemini-2.5-flash-preview-04-17`    | 使用するGeminiモデルの指定です。AI Studioで利用できるモデルコードを設定してください。                                                                                             |
+| **MODEL_CODE**           | false       | `models/gemini-2.5-flash`    | 使用するGeminiモデルの指定です。AI Studioで利用できるモデルコードを設定してください。                                                                                             |
 | **USE_SINGLE_COMMENT_REVIEW** | false | `false`                          | `true`に設定すると、1つのコメントにまとめてレビュー結果を投稿します。<br>`false`の場合は差分にコメントをつける形で複数に分けて投稿します。                                                              |

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Gemini Review Bot
-        uses: Nasubikun/ai-reviewer@v1
+        uses: toshi0806/ai-reviewer@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           LANGUAGE: "Japanese"
           EXCLUDE_PATHS: "**/pnpm-lock.yaml"
-          MODEL_CODE: "models/gemini-2.5-flash-preview-04-17"
+          MODEL_CODE: "models/gemini-2.5-flash-lite"
 ```
 Then, set your Google AI Studio Gemini API Key as GEMINI_API_KEY in your repository’s GitHub Secrets.
 
@@ -41,5 +41,5 @@ You can fine-tune how reviews are performed by setting the following environment
 |--------------------------|------------|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **EXCLUDE_PATHS**        | false       | -                                | 	Specify file paths or directories to exclude from reviews, separated by commas. Example: `src/vendor,**/dist/*`<br>Files matching these paths will not be reviewed.                                    |
 | **LANGUAGE**             | false       | `English`                        | Specifies the language of the AI-generated comments (Example: `Japanese`, `English`).                                                                                                          |                                                                                       |
-| **MODEL_CODE**           | false       | `models/gemini-2.5-flash-preview-04-17`    | The Gemini model to use. Please set a valid model code that is available in AI Studio.                                                                                             |
+| **MODEL_CODE**           | false       | `models/gemini-2.5-flash`    | The Gemini model to use. Please set a valid model code that is available in AI Studio.                                                                                             |
 | **USE_SINGLE_COMMENT_REVIEW** | false | `false`                          | When set to true, posts all review results in a single comment. When set to false, posts multiple comments directly on the relevant parts of the diff.                                                              |

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
   MODEL_CODE:
     description: "Model code for Gemini"
-    default: "models/gemini-2.0-flash-exp"
+    default: "models/gemini-2.5-flash"
   LANGUAGE:
     description: "Preferred language for review comments"
     default: "English"


### PR DESCRIPTION
## Summary
- Update default MODEL_CODE from experimental `gemini-2.0-flash-exp` to stable `gemini-2.5-flash`
- Update README documentation:
  - Change action reference from Nasubikun to toshi0806
  - Update default MODEL_CODE in config table
  - Add MODEL_CODE example with `gemini-2.5-flash-lite` in sample workflow

## Why
- `gemini-2.0-flash-exp` is experimental and has limited free tier quota
- `gemini-2.5-flash` is stable with better free tier support (250 RPD)