### PR TITLE
Add Renovate config using shared smkwlab preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>smkwlab/.github:latex#v1"]
+}


### PR DESCRIPTION
## Summary

Introduce Renovate dependency management by extending the org-wide shared preset, pinned to the `v1` tag.

```jsonc
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["github>smkwlab/.github:latex#v1"]
}
```

This brings `ai-reviewer` in line with the rest of the LaTeX ecosystem: github-actions/docker `pinDigests`, npm `bump`, weekly Sunday schedule, `workarounds:all`, and patch/digest auto-merge — all centrally managed in `smkwlab/.github` (`default.json` + `latex.json` @ `v1`).

## ⚠️ Note on Renovate App installation

This repository lives under **`toshi0806`**, not the `smkwlab` org. Extending a public preset from `smkwlab/.github` works fine, but Renovate will only run here if the **Renovate GitHub App is installed on `toshi0806/ai-reviewer`** (the existing installation covers the `smkwlab` org). Please confirm/enable the App for this repo for updates to take effect.

## Context

Part of the ecosystem-wide Renovate consolidation. Shared presets added/pinned in smkwlab/.github#28 and #29 (both merged, released as `v1.6.0`).
